### PR TITLE
__init__.pyを追加しました

### DIFF
--- a/aozoracli/__init__.py
+++ b/aozoracli/__init__.py
@@ -1,0 +1,1 @@
+from .cli import *

--- a/bin/aozora
+++ b/bin/aozora
@@ -1,13 +1,10 @@
 #!/usr/bin/env python
 
 import sys
-import os
-sys.path.append(os.getcwd())
-
+import aozoracli
 
 def main():
-    import aozoracli.cli
-    return aozoracli.cli.cli()
+    return aozoracli.cli()
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
aozoracli/ に `__init__.py`を追加しました。import aozoracli するとこのディレクトリの下の *.pyが自動でインポートされると思います。そして、aozoracli.cli.cli()は冗長っぽかったので、aozoracli.cli()と出来るようにしてみました。

それから、sys.path.append(os.getcwd()) している所がありましたが、これをしてしまうと、何処にいてもその実行時のディレクトリが追加されてしまうのであまりよろしくないように思いました。setup.pyを追加してこのライブラリがインストールされた時には、Pythonの標準の場所に置かれるのでこれが無くてもimportできるようになると思います。開発時には export PYTHONPATH=. とかしておくと bin/aozora が動かせると思います。
