### PR TITLE
Support author option.

### DIFF
--- a/aozoracli/books.py
+++ b/aozoracli/books.py
@@ -2,8 +2,11 @@
 
 import aozoracli.client
 
+PAYLOAD_KEYS = ['author']
+
 def main(options):
-    books = aozoracli.client.get_books().json()
+    options, payload = _parse_options(options)
+    books = aozoracli.client.get_books(payload).json()
 
     if books == None:
         print("Could not get aozora books data")
@@ -22,7 +25,14 @@ def main(options):
     return True
 
 def _filter(books, key, value):
-    print(key, value)
     return [b for b in books if b[key] == value]
 
+def _parse_options(options):
+    payload = {}
+    for key in PAYLOAD_KEYS:
+        if options[key] == None:
+            continue
+        payload[key] = options.pop('author')
+
+    return (options, payload)
 

--- a/aozoracli/cli.py
+++ b/aozoracli/cli.py
@@ -12,10 +12,12 @@ def cli(ctx):
 @cli.command(help='list books')
 @click.option('--id', required=False, type=int)
 @click.option('--title', required=False)
-def books(id, title):
+@click.option('--author', required=False)
+def books(id, title, author):
     import aozoracli.books
     aozoracli.books.main({
             'id': id,
             'title': title,
+            'author': author,
     })
 

--- a/aozoracli/client.py
+++ b/aozoracli/client.py
@@ -7,5 +7,5 @@ AOZORAPI_URL = "http://{}/api/v0.1".format(AOZORAPI_HOST)
 def main():
      print("Start aozora command line tool")
 
-def get_books():
-    return requests.get(AOZORAPI_URL + "/books")
+def get_books(payload=None):
+    return requests.get(AOZORAPI_URL + "/books", params=payload)


### PR DESCRIPTION
`--author` オプションを追加しました。

APIリクエスト時のクエリーに含めるオプションと、
レスポンスのJSONをパースしてフィルタリングするオプションを切り分けるため、
`_parse_options` 関数を用意しました。

https://github.com/aozorahack/aozora-cli/compare/master...add-author-option#diff-c861cfdacf35483723ed45f12621d1a4R30
