### PR TITLE
修正: python2でリダイレクトに渡すとエラー

### DIFF
--- a/aozoracli/cli.py
+++ b/aozoracli/cli.py
@@ -1,4 +1,6 @@
-import json
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 import click
 import jmespath
 
@@ -64,41 +66,19 @@ def content(id, format, output):
             'format': format,
     })
     # contentは、Jsonレスポンスではないので、とりあえずそのまま出力
-    print(res)
+    print(res.encode("UTF-8"))
 
 def _print(res, output_format):
     if res == False:
         return
 
     if output_format == 'json':
-        output = json.dumps(res, ensure_ascii=False)
+        import json
+        output = json.dumps(res, ensure_ascii=False).encode("UTF-8")
     elif  output_format == 'txt':
-        output = _format_print_txt(res)
+        import aozoracli.output.txt
+        output = aozoracli.output.txt.dump(res)
     else:
         output = res
     print(output)
-
-def _format_print_txt(data):
-    if isinstance(data, list):
-        return "\n".join([_to_txt(d) for d in data])
-    elif isinstance(data, dict):
-        return _format_print_txt(d)
-    else:
-        return str(data)
-
-def _to_txt(data):
-    if isinstance(data, list):
-        output = ""
-        for d in data:
-            output += _to_txt(d)
-        return output
-    elif isinstance(data, dict):
-        sorted_keys = sorted(data.keys())
-        sorted_values = []
-        for key in sorted_keys:
-            val = _to_txt(data[key])
-            sorted_values.append(val)
-        return " ".join(sorted_values)
-    else:
-        return str(data)
 

--- a/aozoracli/cli.py
+++ b/aozoracli/cli.py
@@ -66,7 +66,7 @@ def content(id, format, output):
             'format': format,
     })
     # contentは、Jsonレスポンスではないので、とりあえずそのまま出力
-    print(res.encode("UTF-8"))
+    _print_utf8(res.encode("UTF-8"))
 
 def _print(res, output_format):
     if res == False:
@@ -80,5 +80,12 @@ def _print(res, output_format):
         output = aozoracli.output.txt.dump(res)
     else:
         output = res
-    print(output)
+    _print_utf8(output)
+
+def _print_utf8(output):
+    try:
+        unicode
+        print(output)
+    except:
+        print(output.decode("UTF-8"))
 

--- a/aozoracli/output/txt.py
+++ b/aozoracli/output/txt.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+def dump(res):
+    return _format_print_txt(res)
+
+def _format_print_txt(data):
+    if isinstance(data, list):
+        return "\n".join([_to_txt(d) for d in data])
+    elif isinstance(data, dict):
+        return _format_print_txt(d)
+    else:
+        return str(data)
+
+def _to_txt(data):
+    if data == None:
+        return ""
+
+    if isinstance(data, list):
+        output = ""
+        for d in data:
+            output += _to_txt(d)
+        return output
+    elif isinstance(data, dict):
+        sorted_keys = sorted(data.keys())
+        sorted_values = []
+        for key in sorted_keys:
+            val = _to_txt(data[key])
+            sorted_values.append(val)
+        return " ".join(sorted_values)
+    elif isinstance(data, int):
+        return str(data)
+    else:
+        return data.encode("UTF-8")
+

--- a/bin/aozora
+++ b/bin/aozora
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import sys
 import aozoracli

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email='yasuhiroki.duck@gmail.com',
     url='https://github.com/aozorahack/aozora-cli',
     scripts=['bin/aozora'],
-    packages=['aozoracli'],
+    packages=['aozoracli', 'aozoracli/output'],
     install_requires=['requests', 'click', 'jmespath'],
     license="MIT",
 )


### PR DESCRIPTION
Python2の時、リダイレクト等を使用すると `UnicodeEncodeError` が発生する。
Python2がエンコードを識別できず ascii で試してしまうためなので、明示的に UTF-8 を指定するように。

そうすると python3 ではバイト文字列になってしまうので、python3の時だけUTF-8でデコードするように。
　※ もっと良い方法があるはず...